### PR TITLE
Do state updates inside a transaction

### DIFF
--- a/sources/core/qfunctions/oarnodesetting
+++ b/sources/core/qfunctions/oarnodesetting
@@ -325,6 +325,7 @@ if (defined($last_property_value)) {
 }else{
     if (($#resource >= 0) or (defined($Sql_property))){
         if (defined($state)){
+            OAR::IO::lock_table($base, ["resources"]);
             my @resources_to_check;
             foreach my $r (@resource){
                 if (OAR::IO::set_resource_nextState($base,$r,$state) > 0){
@@ -335,6 +336,7 @@ if (defined($last_property_value)) {
                     $exit_code = 3;
                 }
             }
+            OAR::IO::unlock_table($base);
             OAR::Tools::notify_tcp_socket($remote_host,$remote_port,"ChState");
             if (($state eq 'Dead') || ($state eq 'Absent')){
                 if (!$nowaitMode){


### PR DESCRIPTION
By locking/unlocking the resources table, we create a postgresql
transaction. That greatly helps with the performance of state updates
(going from ~4s to ~0.4s in my oardocker tests with 2000 resources),
because all the constraints checks are delayed until the end of the
transaction.