### PR TITLE
[Scheduler] Add support for job type -t state=permissive

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,9 @@ version 2.5.8:
   - [oarwalltime] add functionality to allow changing the walltime of a
     running job. See the oarwalltime command and oar.conf
   - [scheduler] fix the besteffort + deploy VS adv. reservation case
+  - [scheduler] add the state=permissive job type, allowing jobs to be scheduled
+    and run (if noop or cosystem as well only) regardless of the aliveness of 
+    resources
   - [oarsub/scheduler] fix warning "Use of uninitialized value $resource_value"
   - [oarsub] fix unknown error message in case of job termination + typos
   - [oarnodesetting] do not kill noop jobs using by resources changed to

--- a/sources/core/database/pg_default_admission_rules.sql
+++ b/sources/core/database/pg_default_admission_rules.sql
@@ -200,6 +200,7 @@ my @types = (
     qr/^inner=\\w+$/,                          qr/^timesharing=(?:(?:\\*|user),(?:\\*|name)|(?:\\*|name),(?:\\*|user))$/,
     qr/^token\\:\\w+\\=\\d+$/,                 qr/^noop(?:=standby)?$/,
     qr/^(?:postpone|deadline|expire)=\\d\\d\\d\\d-\\d\\d-\\d\\d(?:\\s+\\d\\d:\\d\\d(?::\\d\\d)?)?$/,
+    qr/^state=permissive$/,
 );
 foreach my $t ( @{$type_list} ) {
     my $match = 0;

--- a/sources/core/modules/scheduler/oar_meta_sched
+++ b/sources/core/modules/scheduler/oar_meta_sched
@@ -478,42 +478,47 @@ sub treate_waiting_reservation_jobs($){
         }
         my @resa_alive_resources;
         my $jobtypes = OAR::IO::get_job_types_hash($base,$job->{job_id});
-        my $standbystart = ((defined($jobtypes->{deploy}) and $jobtypes->{deploy} eq "standby")
-            or (defined($jobtypes->{cosystem}) and $jobtypes->{cosystem} eq "standby")
-            or (defined($jobtypes->{noop}) and $jobtypes->{noop} eq "standby"));
-        if ($standbystart){
-            oar_debug("[MetaSched] [$job->{job_id}] reservation is allowed to start with some resources in standby\n");
-            @resa_alive_resources = OAR::IO::get_gantt_Alive_or_Standby_resources_for_job($base,$moldable->[2], $job->{start_time} + $moldable->[1] + $Security_time_overhead);
+
+        if (defined($jobtypes->{state}) and $jobtypes->{state} eq "permissive" and (defined($jobtypes->{noop}) or defined($jobtypes->{cosystem}))) {
+            oar_warn("[MetaSched] [$job->{job_id}] cosystem/noop advance reservation with permissive resources state: not checking resources aliveness\n");
         } else {
-            @resa_alive_resources = OAR::IO::get_gantt_Alive_resources_for_job($base,$moldable->[2]);
-        }
-        # test if the job is going to be launched and there is no Alive node
-        if (($#resa_alive_resources < 0) && ($job->{start_time} <= $current_time_sec)){
-            oar_warn("[MetaSched] [$job->{job_id}] reservation is waiting because no resource is available\n");
-            OAR::IO::set_gantt_job_startTime($base,$moldable->[2],$current_time_sec + 1);
-        }elsif($job->{start_time} <= $current_time_sec){
-            my @resa_resources = OAR::IO::get_gantt_resources_for_job($base,$moldable->[2]);
-            if ($job->{start_time} + $Reservation_waiting_timeout > $current_time_sec){
-                if ($#resa_resources > $#resa_alive_resources){
-                    # we have not the same number of nodes than in the query --> wait the specified timeout
-                    oar_warn("[MetaSched] [$job->{job_id}] reservation is waiting because not all resources are available yet (timeout in ".($job->{start_time} + $Reservation_waiting_timeout - $current_time_sec)." seconds)\n");
-                    OAR::IO::set_gantt_job_startTime($base,$moldable->[2],($current_time_sec + 1));
-                }
-            }else{
-                #Check if resources are in Alive state otherwise remove them, the job is going to be launched
-                foreach my $r (@resa_resources){
-                    my $resource_info = OAR::IO::get_resource_info($base,$r);
-                    if (not ($resource_info->{state} eq "Alive" or ($standbystart and $resource_info->{state} eq "Absent" and
-                        ($job->{start_time} + $moldable->[1] + $Security_time_overhead) < $resource_info->{available_upto}))){
-                        oar_warn("[MetaSched] [$job->{job_id}] drop resource $r of the reservation, because resource is $resource_info->{state})\n");
-                        OAR::IO::remove_gantt_resource_job($base, $moldable->[2], $r);
+            my $standbystart = ((defined($jobtypes->{deploy}) and $jobtypes->{deploy} eq "standby")
+                or (defined($jobtypes->{cosystem}) and $jobtypes->{cosystem} eq "standby")
+                or (defined($jobtypes->{noop}) and $jobtypes->{noop} eq "standby"));
+            if ($standbystart){
+                oar_debug("[MetaSched] [$job->{job_id}] reservation is allowed to start with some resources in standby\n");
+                @resa_alive_resources = OAR::IO::get_gantt_Alive_or_Standby_resources_for_job($base,$moldable->[2], $job->{start_time} + $moldable->[1] + $Security_time_overhead);
+            } else {
+                @resa_alive_resources = OAR::IO::get_gantt_Alive_resources_for_job($base,$moldable->[2]);
+            }
+            # test if the job is going to be launched and there is no Alive node
+            if (($#resa_alive_resources < 0) && ($job->{start_time} <= $current_time_sec)){
+                oar_warn("[MetaSched] [$job->{job_id}] reservation is waiting because no resource is available\n");
+                OAR::IO::set_gantt_job_startTime($base,$moldable->[2],$current_time_sec + 1);
+            }elsif($job->{start_time} <= $current_time_sec){
+                my @resa_resources = OAR::IO::get_gantt_resources_for_job($base,$moldable->[2]);
+                if ($job->{start_time} + $Reservation_waiting_timeout > $current_time_sec){
+                    if ($#resa_resources > $#resa_alive_resources){
+                        # we have not the same number of nodes than in the query --> wait the specified timeout
+                        oar_warn("[MetaSched] [$job->{job_id}] reservation is waiting because not all resources are available yet (timeout in ".($job->{start_time} + $Reservation_waiting_timeout - $current_time_sec)." seconds)\n");
+                        OAR::IO::set_gantt_job_startTime($base,$moldable->[2],($current_time_sec + 1));
                     }
-                }
-                if ($#resa_resources > $#resa_alive_resources){
-                    OAR::IO::add_new_event($base,"SCHEDULER_REDUCE_NB_NODES_FOR_RESERVATION",$job->{job_id},"[MetaSched] Reduce the number of resources for the job $job->{job_id}.");
-                    my $n = $#resa_alive_resources + 1;
-                    if ($job->{message} =~ s/R\=\d+/R\=$n/g) {
-                        OAR::IO::set_job_message($base,$job->{job_id},$job->{message});
+                }else{
+                    #Check if resources are in Alive state otherwise remove them, the job is going to be launched
+                    foreach my $r (@resa_resources){
+                        my $resource_info = OAR::IO::get_resource_info($base,$r);
+                        if (not ($resource_info->{state} eq "Alive" or ($standbystart and $resource_info->{state} eq "Absent" and
+                            ($job->{start_time} + $moldable->[1] + $Security_time_overhead) < $resource_info->{available_upto}))){
+                            oar_warn("[MetaSched] [$job->{job_id}] drop resource $r of the reservation, because resource is $resource_info->{state})\n");
+                            OAR::IO::remove_gantt_resource_job($base, $moldable->[2], $r);
+                        }
+                    }
+                    if ($#resa_resources > $#resa_alive_resources){
+                        OAR::IO::add_new_event($base,"SCHEDULER_REDUCE_NB_NODES_FOR_RESERVATION",$job->{job_id},"[MetaSched] Reduce the number of resources for the job $job->{job_id}.");
+                        my $n = $#resa_alive_resources + 1;
+                        if ($job->{message} =~ s/R\=\d+/R\=$n/g) {
+                            OAR::IO::set_job_message($base,$job->{job_id},$job->{message});
+                        }
                     }
                 }
             }

--- a/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing
+++ b/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing
@@ -134,8 +134,8 @@ foreach my $i (@{$order}){
     # Do not take care of besteffort jobs
     if ((! defined($types->{besteffort})) or ($queue eq "besteffort")){
         my @resource_list = @{$already_scheduled_jobs{$i}->[3]};
-        my $job_duration = $already_scheduled_jobs{$i}->[1];
         my $resource_list_vec = $already_scheduled_jobs{$i}->[10];
+        my $job_duration = $already_scheduled_jobs{$i}->[1];
         if ($already_scheduled_jobs{$i}->[4] eq "Suspended"){
             # Remove resources of the type specified in SCHEDULER_AVAILABLE_SUSPENDED_RESOURCE_TYPE
             ($resource_list_vec, @resource_list) = OAR::IO::get_job_current_resources($base, $already_scheduled_jobs{$i}->[7],\@Sched_available_suspended_resource_type);
@@ -210,10 +210,10 @@ oar_debug("[$scheduler_name] End phase 1 (running jobs)\n");
 # Begining of the real scheduling
 
 # Get list of Alive resources
-my $alive_resources_vector = '';
-foreach my $r (OAR::IO::get_resources_in_state($base,"Alive")){
-    vec($alive_resources_vector, $r->{resource_id}, 1) = 1;
-}
+my ($Alive_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Alive");
+my ($Absent_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Absent");
+my ($Suspected_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Suspected");
+my ($Dead_resource_id_vec, @Dead_resource_ids) = OAR::IO::get_resource_ids_in_state($base,"Dead");
 
 # ENERGY SAVING: add fake occupations/holes from energy saving configuration 
 # CM part and Hulot part (wake up nodes in energy saving mode)
@@ -224,7 +224,7 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     foreach my $t (keys(%{$upto_availability})){
         my $vec = '';
         foreach my $r (@{$upto_availability->{$t}}){
-            vec($alive_resources_vector, $r, 1) = 1;
+            vec($Alive_resource_id_vec, $r, 1) = 1;
             vec($vec,$r,1) = 1;
         }
         #Fill all the gantts
@@ -254,11 +254,6 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
 }
 # CM part
  
-my @Dead_resources;
-foreach my $r (OAR::IO::get_resources_in_state($base,"Dead")){
-    push(@Dead_resources, $r->{resource_id});
-}
-
 oar_debug("[$scheduler_name] Begin phase 2 (waiting jobs)\n");
 my @jobs = OAR::IO::get_jobs_to_schedule($base,$queue,$max_waiting_jobs_to_schedule);
 my $job_index = 0;
@@ -346,8 +341,11 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
         $gantt_to_use = $timesharing_gantts->{$container_num}->{$user}->{$name};
         oar_debug("[$scheduler_name] [$j->{job_id}] timesharing job: use gantt for ($container_num, $user, $name)\n");
     }
-    #oar_debug("[$scheduler_name] Use gantt for $j->{job_id}:\n".OAR::Schedulers::GanttHoleStorage::pretty_print($gantt_to_use)."\n");
-
+    my $available_resources_vector = $Alive_resource_id_vec;
+    # Allow for scheduling jobs on absent or suspected resources is job has type state=permissive 
+    if (defined($types->{state}) and $types->{state} eq "permissive") {
+        $available_resources_vector |= $Absent_resource_id_vec | $Suspected_resource_id_vec;
+    }
     my $job_properties = "\'1\'";
     if ((defined($j->{properties})) and ($j->{properties} ne "")){
         $job_properties = $j->{properties};
@@ -371,7 +369,7 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
             if ((defined($m->{property})) and ($m->{property} ne "")){
                 $tmp_properties = $m->{property};
             }
-            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$alive_resources_vector,undef,\@Dead_resources,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
+            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$available_resources_vector,undef,\@Dead_resource_ids,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
             $tmp_tree = OAR::Schedulers::ResourceTree::delete_tree_nodes_with_not_enough_resources($tmp_tree);
             push(@tree_list, $tmp_tree);
             #my @leafs = OAR::Schedulers::ResourceTree::get_tree_leafs($tmp_tree);

--- a/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_fairsharing
+++ b/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_fairsharing
@@ -271,10 +271,10 @@ oar_debug("[$scheduler_name] End phase 1 (running jobs)\n");
 # Begining of the real scheduling
 
 # Get list of Alive resources
-my $alive_resources_vector = '';
-foreach my $r (OAR::IO::get_resources_in_state($base,"Alive")){
-    vec($alive_resources_vector, $r->{resource_id}, 1) = 1;
-}
+my ($Alive_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Alive");
+my ($Absent_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Absent");
+my ($Suspected_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Suspected");
+my ($Dead_resource_id_vec, @Dead_resource_ids) = OAR::IO::get_resource_ids_in_state($base,"Dead");
 
 # ENERGY SAVING: add fake occupations/holes from energy saving configuration 
 # CM part and Hulot part (wake up nodes in energy saving mode)
@@ -285,7 +285,7 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     foreach my $t (keys(%{$upto_availability})){
         my $vec = '';
         foreach my $r (@{$upto_availability->{$t}}){
-            vec($alive_resources_vector, $r, 1) = 1;
+            vec($Alive_resource_id_vec, $r, 1) = 1;
             vec($vec,$r,1) = 1;
         }
         #Fill all the gantts
@@ -315,11 +315,6 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
 }
 # CM part
  
-my @Dead_resources;
-foreach my $r (OAR::IO::get_resources_in_state($base,"Dead")){
-    push(@Dead_resources, $r->{resource_id});
-}
-
 oar_debug("[$scheduler_name] Begin phase 2 (waiting jobs)\n");
 my @jobs = OAR::IO::get_fairsharing_jobs_to_schedule($base,$queue,$Karma_max_number_of_jobs_treated_per_user);
 ###############################################################################
@@ -466,8 +461,11 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
         }
         next if ($skip_job == 1);
     }
-    #oar_debug("[$scheduler_name] Use gantt for $j->{job_id}:\n".OAR::Schedulers::GanttHoleStorage::pretty_print($gantt_to_use)."\n");
-
+    my $available_resources_vector = $Alive_resource_id_vec;
+    # Allow for scheduling jobs on absent or suspected resources is job has type state=permissive 
+    if (defined($types->{state}) and $types->{state} eq "permissive") {
+        $available_resources_vector |= $Absent_resource_id_vec | $Suspected_resource_id_vec;
+    }
     my $job_properties = "\'1\'";
     if ((defined($j->{properties})) and ($j->{properties} ne "")){
         $job_properties = $j->{properties};
@@ -491,7 +489,7 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
             if ((defined($m->{property})) and ($m->{property} ne "")){
                 $tmp_properties = $m->{property};
             }
-            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$alive_resources_vector,undef,\@Dead_resources,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
+            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$available_resources_vector,undef,\@Dead_resource_ids,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
             $tmp_tree = OAR::Schedulers::ResourceTree::delete_tree_nodes_with_not_enough_resources($tmp_tree);
             push(@tree_list, $tmp_tree);
             #my @leafs = OAR::Schedulers::ResourceTree::get_tree_leafs($tmp_tree);

--- a/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_fairsharing_and_placeholder
+++ b/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_fairsharing_and_placeholder
@@ -222,10 +222,10 @@ oar_debug("[$scheduler_name] End phase 1 (running jobs)\n");
 # Begining of the real scheduling
 
 # Get list of Alive resources
-my $alive_resources_vector = '';
-foreach my $r (OAR::IO::get_resources_in_state($base,"Alive")){
-    vec($alive_resources_vector, $r->{resource_id}, 1) = 1;
-}
+my ($Alive_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Alive");
+my ($Absent_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Absent");
+my ($Suspected_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Suspected");
+my ($Dead_resource_id_vec, @Dead_resource_ids) = OAR::IO::get_resource_ids_in_state($base,"Dead");
 
 # ENERGY SAVING: add fake occupations/holes from energy saving configuration 
 # CM part and Hulot part (wake up nodes in energy saving mode)
@@ -236,7 +236,7 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     foreach my $t (keys(%{$upto_availability})){
         my $vec = '';
         foreach my $r (@{$upto_availability->{$t}}){
-            vec($alive_resources_vector, $r, 1) = 1;
+            vec($Alive_resource_id_vec, $r, 1) = 1;
             vec($vec,$r,1) = 1;
         }
         #Fill all the gantts
@@ -258,11 +258,6 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     oar_debug("[$scheduler_name] End EnergySaving phase\n");
 }
 # CM part
- 
-my @Dead_resources;
-foreach my $r (OAR::IO::get_resources_in_state($base,"Dead")){
-    push(@Dead_resources, $r->{resource_id});
-}
 
 oar_debug("[$scheduler_name] Begin phase 2 (waiting jobs)\n");
 my @jobs = OAR::IO::get_fairsharing_jobs_to_schedule($base,$queue,$Karma_max_number_of_jobs_treated_per_user);
@@ -411,6 +406,11 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
         }
         next if ($skip_job == 1);
     }
+    my $available_resources_vector = $Alive_resource_id_vec;
+    # Allow for scheduling jobs on absent or suspected resources is job has type state=permissive 
+    if (defined($types->{state}) and $types->{state} eq "permissive") {
+        $available_resources_vector |= $Absent_resource_id_vec | $Suspected_resource_id_vec;
+    }
     my $job_properties = "\'1\'";
     if ((defined($j->{properties})) and ($j->{properties} ne "")){
         $job_properties = $j->{properties};
@@ -433,7 +433,7 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
             if ((defined($m->{property})) and ($m->{property} ne "")){
                 $tmp_properties = $m->{property};
             }
-            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$alive_resources_vector,undef,\@Dead_resources,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
+            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$available_resources_vector,undef,\@Dead_resource_ids,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
             $tmp_tree = OAR::Schedulers::ResourceTree::delete_tree_nodes_with_not_enough_resources($tmp_tree);
             push(@tree_list, $tmp_tree);
         }

--- a/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_fairsharing_and_quotas
+++ b/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_fairsharing_and_quotas
@@ -232,6 +232,7 @@ foreach my $i (@{$order}){
                                                 $already_scheduled_jobs{$i}->[5]
                                                                      );
         }
+
         #Handle a job within a container
         my $container_num = 0;
         if (defined($types->{inner}) and ($types->{inner} =~ /^(\d+)$/)){
@@ -264,7 +265,6 @@ foreach my $i (@{$order}){
                                                     $resource_list_vec
                                                                              );
             }
-            #OAR::Schedulers::GanttHoleStorage_with_quotas::pretty_print($Container_gantt_hash{$g});
         }
         foreach my $c (keys(%{$timesharing_gantts})){
             foreach my $u (keys(%{$timesharing_gantts->{$c}})){
@@ -292,7 +292,10 @@ oar_debug("[$scheduler_name] End phase 1 (running jobs)\n");
 # Begining of the real scheduling
 
 # Get list of Alive resources
-my ($alive_resources_vector, @alive_resources)= OAR::IO::get_resource_ids_in_state($base,"Alive");
+my ($Alive_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Alive");
+my ($Absent_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Absent");
+my ($Suspected_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Suspected");
+my ($Dead_resource_id_vec, @Dead_resource_ids) = OAR::IO::get_resource_ids_in_state($base,"Dead");
 
 # ENERGY SAVING: add fake occupations/holes from energy saving configuration 
 # CM part and Hulot part (wake up nodes in energy saving mode)
@@ -303,7 +306,7 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     foreach my $t (keys(%{$upto_availability})){
         my $vec = '';
         foreach my $r (@{$upto_availability->{$t}}){
-            vec($alive_resources_vector, $r, 1) = 1;
+            vec($Alive_resource_id_vec, $r, 1) = 1;
             vec($vec,$r,1) = 1;
         }
         #Fill all the gantts
@@ -335,8 +338,6 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
 }
 # CM part
  
-my ($Dead_resources_vec, @Dead_resources) = OAR::IO::get_resource_ids_in_state($base,"Dead");
-
 oar_debug("[$scheduler_name] Begin phase 2 (waiting jobs)\n");
 my @jobs = OAR::IO::get_fairsharing_jobs_to_schedule($base,$queue,$Karma_max_number_of_jobs_treated_per_user);
 ###############################################################################
@@ -487,6 +488,11 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
     #OAR::Schedulers::GanttHoleStorage_with_quotas::pretty_print($gantt_to_use);
     #oar_debug("[$scheduler_name] [$j->{job_id}] Gantt data structure:\n".OAR::Schedulers::GanttHoleStorage_with_quotas::pretty_print($gantt_to_use));
 
+    my $available_resources_vector = $Alive_resource_id_vec;
+    # Allow for scheduling jobs on absent or suspected resources is job has type state=permissive 
+    if (defined($types->{state}) and $types->{state} eq "permissive") {
+        $available_resources_vector |= $Absent_resource_id_vec | $Suspected_resource_id_vec;
+    }
     my $job_properties = "\'1\'";
     if ((defined($j->{properties})) and ($j->{properties} ne "")){
         $job_properties = $j->{properties};
@@ -509,7 +515,7 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
             if ((defined($m->{property})) and ($m->{property} ne "")){
                 $tmp_properties = $m->{property};
             }
-            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$alive_resources_vector,undef,\@Dead_resources,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
+            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$available_resources_vector,undef,\@Dead_resource_ids,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
             push(@tree_list, $tmp_tree);
         }
         my $gantt_timeout =  ($timeout - (time() - $initial_time)) / 4;

--- a/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_placeholder
+++ b/sources/core/modules/scheduler/oar_sched_gantt_with_timesharing_and_placeholder
@@ -163,10 +163,10 @@ oar_debug("[$scheduler_name] End phase 1 (running jobs)\n");
 # Begining of the real scheduling
 
 # Get list of Alive resources
-my $alive_resources_vector = '';
-foreach my $r (OAR::IO::get_resources_in_state($base,"Alive")){
-    vec($alive_resources_vector, $r->{resource_id}, 1) = 1;
-}
+my ($Alive_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Alive");
+my ($Absent_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Absent");
+my ($Suspected_resource_id_vec, undef) = OAR::IO::get_resource_ids_in_state($base,"Suspected");
+my ($Dead_resource_id_vec, @Dead_resource_ids) = OAR::IO::get_resource_ids_in_state($base,"Dead");
 
 # ENERGY SAVING: add fake occupations/holes from energy saving configuration 
 # CM part and Hulot part (wake up nodes in energy saving mode)
@@ -177,7 +177,7 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     foreach my $t (keys(%{$upto_availability})){
         my $vec = '';
         foreach my $r (@{$upto_availability->{$t}}){
-            vec($alive_resources_vector, $r, 1) = 1;
+            vec($Alive_resource_id_vec, $r, 1) = 1;
             vec($vec,$r,1) = 1;
         }
         #Fill all the gantts
@@ -199,11 +199,6 @@ if (is_conf("SCHEDULER_NODE_MANAGER_WAKE_UP_CMD") or (get_conf("ENERGY_SAVING_IN
     oar_debug("[$scheduler_name] End EnergySaving phase\n");
 }
 # CM part
- 
-my @Dead_resources;
-foreach my $r (OAR::IO::get_resources_in_state($base,"Dead")){
-    push(@Dead_resources, $r->{resource_id});
-}
 
 oar_debug("[$scheduler_name] Begin phase 2 (waiting jobs)\n");
 my @jobs = OAR::IO::get_jobs_to_schedule($base,$queue,$max_waiting_jobs_to_schedule);
@@ -293,7 +288,11 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
         ($placeholder_name, $allowed_name, $timesharing_user, $timesharing_name) =
             OAR::Schedulers::GanttHoleStorage::manage_gantt_for_timesharing_and_placeholder($Gantt, $j->{job_user}, $j->{job_name}, $types, $inner_id, "[$scheduler_name] [$i]");
     }
-
+    my $available_resources_vector = $Alive_resource_id_vec;
+    # Allow for scheduling jobs on absent or suspected resources is job has type state=permissive 
+    if (defined($types->{state}) and $types->{state} eq "permissive") {
+        $available_resources_vector |= $Absent_resource_id_vec | $Suspected_resource_id_vec;
+    }
     my $job_properties = "\'1\'";
     if ((defined($j->{properties})) and ($j->{properties} ne "")){
         $job_properties = $j->{properties};
@@ -316,7 +315,7 @@ while (($job_index <= $#jobs) and ((time() - $initial_time) < $timeout)){
             if ((defined($m->{property})) and ($m->{property} ne "")){
                 $tmp_properties = $m->{property};
             }
-            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$alive_resources_vector,undef,\@Dead_resources,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
+            my $tmp_tree = OAR::IO::get_possible_wanted_resources($base_ro,$available_resources_vector,undef,\@Dead_resource_ids,"$job_properties AND $tmp_properties", $m->{resources}, $Order_part);
             $tmp_tree = OAR::Schedulers::ResourceTree::delete_tree_nodes_with_not_enough_resources($tmp_tree);
             push(@tree_list, $tmp_tree);
         }


### PR DESCRIPTION
with -t state=permissive, a batch job is scheduled regardless of having
some resources in state Absent or Suspected (already the case for
advance reservations).

However, the job will never run (it is always rescheduled in the
future), unless its resources become Alive at some time...

... Unless it has also the cosystem or noop job type, in which case it
will start regardless of the state of the resources: Absent, Suspected
or even Dead.

(could be usefull to overcome the lack of fairsharing for advance
reservations)

TODO: add code to other schedulers