### PR TITLE
adding an index on resource_logs (resource_id, date_stop, attribute) …

### DIFF
--- a/sources/core/database/pg_structure.sql
+++ b/sources/core/database/pg_structure.sql
@@ -281,6 +281,7 @@ CREATE INDEX finaud ON resource_logs (finaud_decision);
 CREATE INDEX val ON resource_logs (value);
 CREATE INDEX date_start ON resource_logs (date_start);
 CREATE INDEX date_stop ON resource_logs (date_stop);
+CREATE INDEX ix_resource_logs_id_dstop_attr ON resource_logs (resource_id, date_stop, attribute);
 
 
 CREATE TABLE resources (


### PR DESCRIPTION
…for perf reasons

This change helps a lot on big clusters (100+ machines).

Note: I've just changed `pg_structure.sql`. I don't know if it's necessary to add a new `pg_structure_upgrade_[current_version]-[future_version].sql` with this change ?