### PR TITLE
[Stat.pm] fix OAR::IO::count_jobs_for_user_query() arguments.

### DIFF
--- a/sources/core/common-libs/lib/OAR/Stat.pm
+++ b/sources/core/common-libs/lib/OAR/Stat.pm
@@ -148,7 +148,7 @@ sub count_jobs_for_user_query {
     $state = $statement;
 	}
 
-	my $total =  OAR::IO::count_jobs_for_user_query($base,$from,$to,$state,$user,undef,undef,$array,$ids);
+	my $total =  OAR::IO::count_jobs_for_user_query($base,$from,$to,$state,undef,undef,$user,$array,$ids);
 	return $total;
 }
 


### PR DESCRIPTION
Salut,

J'ai remarqué que l'API REST retournait le mauvais nombre de jobs quand le paramètre "user" était spécifié: il semblerait que dans le module Stat.pm, l'appel à OAR::IO::count_jobs_for_user_query() se fasse avec les paramètres dans le mauvais ordre.

Pour référence, dans https://github.com/oar-team/oar/blob/2.5/sources/core/common-libs/lib/OAR/IO.pm ligne 4444:
```
sub count_jobs_for_user_query {
	my $dbh = shift;
    my $date_start = shift || "";
    my $date_end = shift || "";
    my $state = shift || "";
    my $limit = shift || "";
    my $offset = shift;
    my $user = shift || "";
    my $array_id = shift || "";
    my $ids = shift || [];
[...]
```

Voici une simple requete pour corriger le problème, bonne journée