### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 oar (2.5.8-3) UNRELEASED; urgency=medium
 
   * Wrap long lines in changelog entries: 2.5.3-3.
+  * Use secure URI in Homepage field.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 22:21:45 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+oar (2.5.8-3) UNRELEASED; urgency=medium
+
+  * Wrap long lines in changelog entries: 2.5.3-3.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 22:21:45 +0000
+
 oar (2.5.8-2) unstable; urgency=medium
 
   * Revert to stretch behavior for Storable::dclone perl function (Closes:
@@ -221,8 +227,8 @@ oar (2.5.3-3) unstable; urgency=low
   * Fix oar-user dependency on oar-user-mysql or oar-user-postgresql
   * Fix prologues and epilogues configuration files permissions:
     add patch to set mod 0755
-  * Fix oarsub copyright in pod (man), this corrects the "FTBFS with perl 5.18: POD failure" reported by Debian
-    (Closes: #720431)
+  * Fix oarsub copyright in pod (man), this corrects the "FTBFS with perl 5.18:
+    POD failure" reported by Debian (Closes: #720431)
   * Fix the database structure version: must be 2.5.2
 
  -- Pierre Neyron <pierre.neyron@free.fr>  Mon, 09 Sep 2013 00:03:38 +0200

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ oar (2.5.8-3) UNRELEASED; urgency=medium
 
   * Wrap long lines in changelog entries: 2.5.3-3.
   * Use secure URI in Homepage field.
+  * Update standards version to 4.5.0, no changes needed.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Apr 2020 22:21:45 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper-compat (= 12),
                po-debconf,
                perl,
                python3-sphinx
-Standards-Version: 4.3.0
+Standards-Version: 4.5.0
 Vcs-Git: https://github.com/oar-team/oar.git/ -b debian.org
 Vcs-Browser: https://github.com/oar-team/oar
 Homepage: https://oar.imag.fr/

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Build-Depends: debhelper-compat (= 12),
 Standards-Version: 4.3.0
 Vcs-Git: https://github.com/oar-team/oar.git/ -b debian.org
 Vcs-Browser: https://github.com/oar-team/oar
-Homepage: http://oar.imag.fr/
+Homepage: https://oar.imag.fr/
 
 Package: liboar-perl
 Architecture: any


### PR DESCRIPTION
Fix some issues reported by lintian
* Wrap long lines in changelog entries: 2.5.3-3. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Update standards version to 4.5.0, no changes needed. ([out-of-date-standards-version](https://lintian.debian.org/tags/out-of-date-standards-version.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/oar/00de6a08-9cc5-496e-9be1-4dc40d6052aa.


These changes affect the binary packages; see the
[debdiff](https://janitor.debian.net/api/run/00de6a08-9cc5-496e-9be1-4dc40d6052aa/debdiff?filter_boring=1)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/00de6a08-9cc5-496e-9be1-4dc40d6052aa/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/00de6a08-9cc5-496e-9be1-4dc40d6052aa/diffoscope)).
