### PR TITLE
[criu] added a sleep after pid migrations

### DIFF
--- a/misc/checkpointing/criu/criu-daemon.bash
+++ b/misc/checkpointing/criu/criu-daemon.bash
@@ -91,6 +91,7 @@ do
           do
 	    echo $pid >> $cpuset/tasks
 	  done
+          sleep 3
 	  rmdir $original_cpuset
           touch resume_ok
 	  chown $job_user resume_ok


### PR DESCRIPTION
Otherwise, the original cpuset could not always be deleted as it was not yet
empty