### PR TITLE
Remove deprecated option in sshd config

### DIFF
--- a/sources/core/tools/sshd_config.in
+++ b/sources/core/tools/sshd_config.in
@@ -9,8 +9,6 @@ Protocol 2
 # HostKeys for protocol version 2
 HostKey %%OARCONFDIR%%/oar_ssh_host_rsa_key
 #HostKey %%OARCONFDIR%%/oar_ssh_host_dsa_key
-#Privilege Separation is turned on for security
-UsePrivilegeSeparation yes
 
 # Lifetime and size of ephemeral version 1 server key
 #KeyRegenerationInterval 3600


### PR DESCRIPTION
From the [OpenSSH 7.5 release notes](https://www.openssh.com/txt/release-7.5) (release date March 20, 2017):

> This release deprecates the sshd_config UsePrivilegeSeparation
> option, thereby making privilege separation mandatory. Privilege
> separation has been on by default for almost 15 years and
> sandboxing has been on by default for almost the last five.

The option caused warnings when running oar-node on Debian 10:
```
Jul 27 15:56:15 oar-0 oar-node[95]: Starting OAR node: /etc/oar/sshd_config line 13: Deprecated option UsePrivilegeSeparation
```


Hat tip to @lpirl for pointing to the OpenSSH release notes in CISOfy/lynis issue 430