### PR TITLE
oarapi.pl: allow to set fcgi_max_cycle_count to 0 to disable it.

### DIFF
--- a/sources/api/oarapi.pl
+++ b/sources/api/oarapi.pl
@@ -2894,7 +2894,7 @@ EOS
         OAR::API::ERROR(404, "Not found", "No way to handle your request " . $q->path_info);
     }
 
-    if ($fcgi_cycle_count > $fcgi_max_cycle_count) {
+    if (($fcgi_max_cycle_count > 0) && ($fcgi_cycle_count > $fcgi_max_cycle_count)) {
         exit 0;
     }
 


### PR DESCRIPTION
I have found that oar-api can be run through spawnfcgi, for example, to work with another httpd in a Apache-free setup.

The only issue I have is that the script is set to run  a configurable number of time (OAR_FCGI_MAX_CYCLE_COUNT) and die, and this cannot be disabled.

This PR propose to very easily to use the value 0 to disable this behavior, would you consider it? Default behavior is kept as it is.

Regards,