### PR TITLE
[Doc] Be explicit about array-param-file arguments

### DIFF
--- a/sources/core/man/man1/oarsub.pod
+++ b/sources/core/man/man1/oarsub.pod
@@ -73,6 +73,8 @@ Array jobs can neither be Interactive (-I) nor a reservation (-r).
 
 Submit a parametric array job. Each non-empty line of "FILE" defines the parameters for a subjob. All the subjobs have the same characteristics (script, requirements) and can be identified by an environment variable $OAR_ARRAY_INDEX.   '#' is the comment sign.
 
+Parameters are given as arguments to the command.
+
 Parametric array jobs can neither be Interactive (-I) nor a reservation (-r).
 
 =item B<-S, --scanscript>


### PR DESCRIPTION
The documentation of --array-param-file states:

"Submit a parametric array job. Each non-empty line of "FILE" defines the parameters for a subjob."

It's unclear what "parameters" refer to in this context. OAR mostly uses environment variables to "pass" information. I wondered what could be the format, for instance VAR=VAL or if it would be given as an environment variable like OAR_ARRAY_PARAMETER.

Adding a line explicitly using the more common term "arguments" helps to understand the parameters can be recovered from the command line arguments.

"Parameters are given as arguments to the command."

It won't solve world peace, but might help the next person.
