### PR TITLE
Test if user bashrc exists before sourcing it in /var/lib/oar/.batch_job_bashrc

### DIFF
--- a/setup/common.sh.in
+++ b/setup/common.sh.in
@@ -96,7 +96,9 @@ EOF
 # OAR bash environnement file for only the batch job users
 #
 
-source ~/.bashrc
+if [ -f ~/.bashrc ]; then
+    source ~/.bashrc
+fi
 
 EOF
     touch ${OARHOMEDIR}/.bash_profile


### PR DESCRIPTION
In /var/lib/oar/.batch_job_bashrc there is no test if bashrc exists before sourcing it. This leads to messages like:

[local] /var/lib/oar/.batch_job_bashrc: line 5: /home/nigreneche/.bashrc: No such file or directory
[local] /var/lib/oar/.batch_job_bashrc: line 5: /home/nigreneche/.bashrc: No such file or directory

In job log files.