### PR TITLE
Install and use sysusers.d/tmpfiles.d config files

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Uploaders: Vincent Danjean <vdanjean@debian.org>
 Section: utils
 Priority: optional
 Build-Depends: debhelper-compat (= 13),
+               dh-sequence-installsysusers,
                po-debconf,
                perl,
                python3-sphinx,
@@ -41,7 +42,6 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          ${perl:Depends},
          liboar-perl (= ${binary:Version}),
-         adduser,
          ucf,
          hwloc-nox (>= 2.12) | hwloc (>= 2.12),
          libbpf1

--- a/debian/oar-common.postrm
+++ b/debian/oar-common.postrm
@@ -17,48 +17,6 @@ case "$1" in
 	    ;;
 	purge)
 
-            # find first and last SYSTEM_UID numbers
-            for LINE in `grep SYSTEM_UID /etc/adduser.conf | grep -v "^#"`; do
-                case $LINE in
-                    FIRST_SYSTEM_UID*)
-                        FIRST_SYSTEM_UID=`echo $LINE | cut -f2 -d '='`
-                        ;;
-                    LAST_SYSTEM_UID*)
-                        LAST_SYSTEM_UID=`echo $LINE | cut -f2 -d '='`
-                        ;;
-                    *)
-                        ;;
-                esac
-            done
-            # Remove system account if necessary
-            CREATEDUSER="$OAROWNER"
-            if [ -n "$FIRST_SYSTEM_UID" ] && [ -n "$LAST_SYSTEM_UID" ]; then
-                if USERID=`getent passwd $CREATEDUSER | cut -f 3 -d ':'`; then
-                    if [ -n "$USERID" ]; then
-                        if [ "$FIRST_SYSTEM_UID" -le "$USERID" ] && \
-                            [ "$USERID" -le "$LAST_SYSTEM_UID" ]; then
-                        echo -n "Removing $CREATEDUSER system user.."
-                        deluser --quiet $CREATEDUSER || true
-                        echo "..done"
-                    fi
-                fi
-            fi
-        fi
-        # Remove system group if necessary
-        CREATEDGROUP=$OAROWNERGROUP
-        FIRST_USER_GID=$(grep ^USERS_GID /etc/adduser.conf | cut -f2 -d '=')
-        if [ -n "$FIRST_USER_GID" ]; then
-            if GROUPGID=$(getent group $CREATEDGROUP | cut -f 3 -d ':'); then
-                if [ -n "$GROUPGID" ]; then
-                    if [ "$FIRST_USER_GID" -gt "$GROUPGID" ]; then
-                        echo -n "Removing $CREATEDGROUP group.."
-                        delgroup --only-if-empty $CREATEDGROUP || true
-                        echo "..done"
-                    fi
-                fi
-            fi
-        fi
-
         # Remove the possible conffiles 
         for conffile in /etc/oar/oar.conf \
                         /etc/oar/oarnodesetting_ssh \

--- a/debian/oar-common.sysusers
+++ b/debian/oar-common.sysusers
@@ -1,0 +1,1 @@
+u oar - - /var/lib/oar /usr/lib/oar/oarsh_shell

--- a/debian/oar-common.tmpfiles
+++ b/debian/oar-common.tmpfiles
@@ -1,0 +1,2 @@
+d /var/lib/oar 2755 oar oar
+f /var/log/oar.log 0644 oar root

--- a/setup/common.sh.in
+++ b/setup/common.sh.in
@@ -3,7 +3,7 @@ create_oar_group() {
         echo -n "Adding group ${OAROWNERGROUP}.."
         case "$TARGET_DIST" in
             "debian")
-                addgroup --quiet --system ${OAROWNERGROUP} 2>/dev/null || true
+                systemd-sysusers ${DPKG_ROOT:+--root="$DPKG_ROOT"} oar-common.conf
                 ;;
             *)
                 groupadd --system ${OAROWNERGROUP} 2>/dev/null  >/dev/null || true
@@ -23,17 +23,7 @@ create_oar_user() {
         echo -n "Adding system user ${OAROWNER}.."
         case "$TARGET_DIST" in
             "debian")
-                adduser --quiet \
-                        --system \
-                        --ingroup ${OAROWNERGROUP} \
-                        --shell /bin/bash \
-                        --no-create-home \
-                        --disabled-password \
-                        ${OAROWNER} 2>/dev/null || true
-                # Force the "disabled password flag to '*' instead of '!'.
-                # Required in Debian12 (adduser >= 3.130), which changes to way
-                # adduser's --disabled-(login|password) options work.
-                usermod -p '*' ${OAROWNER} || true
+                systemd-sysusers ${DPKG_ROOT:+--root="$DPKG_ROOT"} oar-common.conf
                 ;;
             *)
                 useradd --system \
@@ -55,10 +45,7 @@ create_oar_user() {
     # Adjust the file and directory permissions
     case "$SETUP_TYPE" in
         "deb")
-            if ! dpkg-statoverride --list ${OARHOMEDIR} >/dev/null; then
-                chown $OAROWNER:$OAROWNERGROUP $OARHOMEDIR
-                chmod u=rwx,g=rxs,o= $OARHOMEDIR
-            fi
+            systemd-tmpfiles ${DPKG_ROOT:+--root="$DPKG_ROOT"} --create oar-common.conf
             ;;
         *)
             chown $OAROWNER:$OAROWNERGROUP $OARHOMEDIR


### PR DESCRIPTION
sysusers.d/tmpfiles.d config files allow a package to use declarative configuration instead of manually written maintainer scripts. This also allows image-based systems to be created with /usr/ only, and also allows for factory resetting a system and recreating /etc/ on boot. https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html https://www.freedesktop.org/software/systemd/man/latest/tmpfiles.d.html Note that this does not require a hard dependency on systemd, debhelper generates depetencies correctly so that they work out of the box on non-systemd and non-linux Debian builds seamlessly.